### PR TITLE
New flag ALLOW_MOVE_ON_SAME_CONTENT 

### DIFF
--- a/FileManager.php
+++ b/FileManager.php
@@ -47,6 +47,16 @@ final class FileManager
     const STRATEGY_RENAME_INC = 16;
 
     /**
+     * When moving files, on name conflict, by default move is prevented if
+     * the files shares the same content (tested via cheksum).
+     * Using this flag you will prevent this checksum test and allow
+     * a move on the same file. This can be used to ensure the rename()
+     * operation is really removing the source file from the initial
+     * directory, as it may not be the case withour this flag.
+     */
+    const ALLOW_MOVE_ON_SAME_CONTENT = 32;
+
+    /**
      * No strategy, just put the file in the destination folder, this is the
      * default behaviour.
      */
@@ -465,10 +475,10 @@ final class FileManager
 
             // Attempt a sha1 over both the file content, and do not fail
             // or proceed if files have the same type and sha1 sum.
-            // @todo this should not be a default behaviour, a user might
-            //   want to let same files to be uploaded.
-            if (self::unsafeIsDuplicateOf($filename, $destFilename)) {
-                return $destFilename;
+            if (! ($flags & self::ALLOW_MOVE_ON_SAME_CONTENT)) {
+                if (self::unsafeIsDuplicateOf($filename, $destFilename)) {
+                    return $destFilename;
+                }
             }
 
             if ($flags & self::MOVE_CONFLICT_OVERWRITE) {


### PR DESCRIPTION
to prevent cheksum on rename operation.

My use case was tests, where lots of very small files were generated, sometimes sharing the same content. Some of these files were not renamed on rename() operations and were later re-detected by further tests.

I have to empty a directory of files, and I expeted rename operations to empty that directory.

using :

```
$uri = $this->fileManager->rename(
            $uri,
            $destination,
            FileManager::MOVE_CONFLICT_RENAME ^ fileManager::ALLOW_MOVE_ON_SAME_CONTENT
        );
```
I'm now sure that the directory is empty when all files are managed.